### PR TITLE
[CPU] 基礎データ構造とレジスタ・メモリマップの定義

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,0 +1,97 @@
+pub trait Mem {
+    fn mem_read(&self, addr: u16) -> u8;
+    fn mem_write(&mut self, addr: u16, data: u8);
+
+    fn mem_read_u16(&self, pos: u16) -> u16 {
+        let lo = self.mem_read(pos) as u16;
+        let hi = self.mem_read(pos + 1) as u16;
+        (hi << 8) | (lo as u16)
+    }
+
+    fn mem_write_u16(&mut self, pos: u16, data: u16) {
+        let hi = (data >> 8) as u8;
+        let lo = (data & 0xff) as u8;
+        self.mem_write(pos, lo);
+        self.mem_write(pos + 1, hi);
+    }
+}
+
+pub struct CPU {
+    pub register_a: u8,
+    pub register_x: u8,
+    pub register_y: u8,
+    pub status: u8,
+    pub program_counter: u16,
+    pub stack_pointer: u8,
+    pub memory: [u8; 0xFFFF],
+}
+
+impl Mem for CPU {
+    fn mem_read(&self, addr: u16) -> u8 {
+        self.memory[addr as usize]
+    }
+
+    fn mem_write(&mut self, addr: u16, data: u8) {
+        self.memory[addr as usize] = data;
+    }
+}
+
+impl CPU {
+    pub fn new() -> Self {
+        CPU {
+            register_a: 0,
+            register_x: 0,
+            register_y: 0,
+            status: 0,
+            program_counter: 0,
+            stack_pointer: 0xFF,
+            memory: [0; 0xFFFF],
+        }
+    }
+
+    pub fn update_zero_and_negative_flags(&mut self, result: u8) {
+        if result == 0 {
+            self.status = self.status | 0b0000_0010;
+        } else {
+            self.status = self.status & 0b1111_1101;
+        }
+
+        if result & 0b1000_0000 != 0 {
+            self.status = self.status | 0b1000_0000;
+        } else {
+            self.status = self.status & 0b0111_1111;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cpu_init() {
+        let cpu = CPU::new();
+        assert_eq!(cpu.register_a, 0);
+        assert_eq!(cpu.register_x, 0);
+        assert_eq!(cpu.register_y, 0);
+        assert_eq!(cpu.status, 0);
+        assert_eq!(cpu.program_counter, 0);
+        assert_eq!(cpu.stack_pointer, 0xFF);
+    }
+
+    #[test]
+    fn test_update_zero_flag() {
+        let mut cpu = CPU::new();
+        cpu.update_zero_and_negative_flags(0);
+        assert_eq!(cpu.status & 0b0000_0010, 0b0000_0010);
+        assert_eq!(cpu.status & 0b1000_0000, 0);
+    }
+
+    #[test]
+    fn test_update_negative_flag() {
+        let mut cpu = CPU::new();
+        cpu.update_zero_and_negative_flags(0x80); // 1000 0000
+        assert_eq!(cpu.status & 0b1000_0000, 0b1000_0000);
+        assert_eq!(cpu.status & 0b0000_0010, 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod cpu;
+
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
Resolves #2

### 内容
* `CPU` 構造体の定義と、各レジスタ (`register_a`, `register_x`, `register_y`, `status`, `program_counter`, `stack_pointer`) の初期化処理
* 仮のメモリ空間 (`memory: [u8; 0xFFFF]`) の追加
* メモリバスを模した `Mem` トレイトへの `mem_read`, `mem_write`, `mem_read_u16`, `mem_write_u16` の実装と `CPU` への適用
* ステータスフラグ (Zero, Negative) を更新する関数 `update_zero_and_negative_flags` の作成
* 初期化とフラグ更新に関するユニットテストの追加